### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release": "pnpm changeset version && pnpm changeset tag"
   },
   "files": [],
-  "repository": "git@github.com:medfreeman/swc-plugin-add-import-extension.git",
+  "repository": "git+https://github.com/medfreeman/swc-plugin-add-import-extension.git",
   "homepage": "https://github.com/medfreeman/swc-plugin-add-import-extension",
   "bugs": "https://github.com/medfreeman/swc-plugin-add-import-extension/issues",
   "engines": {


### PR DESCRIPTION
# Upstream PR packet

## Title

chore: use public repository metadata

## Body

## Summary

- update the package repository metadata from SSH-style `git@github.com:medfreeman/swc-plugin-add-import-extension.git` to public `git+https://github.com/medfreeman/swc-plugin-add-import-extension.git`
- leave runtime code, build configuration, dependencies, package version, homepage, bugs, and published files unchanged

## Validation

- `npm view swc-plugin-add-import-extension name version repository homepage bugs license --json`
- `node -e 'const p=require("./package.json"); if (p.repository!=="git+https://github.com/medfreeman/swc-plugin-add-import-extension.git") throw new Error(String(p.repository));'`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json .`

